### PR TITLE
`pre-commit` and updated repo name

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,17 @@
+---
+name: Lint and Test
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,7 +1,8 @@
+---
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
 name: Deploy Hugo site to Pages
 
-on:
+on: # yamllint disable-line rule:truthy
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
@@ -15,10 +16,12 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. However, do NOT cancel in-progress runs as we
+# want to allow these production deployments to complete.
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Default to bash
 defaults:
@@ -33,16 +36,18 @@ jobs:
       HUGO_VERSION: 0.102.3
     steps:
       - name: Install Hugo CLI
+        # yamllint disable rule:line-length
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
+        # yamllint enable rule:line-length
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v3
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules
@@ -67,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,42 @@
+---
+default_language_version:
+  python: python3
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-byte-order-marker
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: pretty-format-json
+        args: [--autofix, --no-sort-keys]
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.32.0
+    hooks:
+      - id: yamllint
+        args: [--strict]
+  - repo: https://github.com/myint/rstcheck
+    rev: v6.1.2
+    hooks:
+      - id: rstcheck
+        additional_dependencies:
+          - sphinx
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0
+    hooks:
+      - id: prettier
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args:
+          - --check-filenames
+          - --check-hidden

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,12 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: mixed-line-ending
+        exclude: .gitignore
       - id: pretty-format-json
         args: [--autofix, --no-sort-keys]
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+        exclude: .gitignore
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.32.0
     hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1  # Match prettier

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# onetwofoureight
+# onetwofoureight.com
+
+Files underpinning https://onetwofoureight.com/
 
 ## Website
 
-This website was made with the static site generator [Hugo](https://gohugo.io/).
-
-The theme [jamesbraza/hermit](https://github.com/jamesbraza/hermit)
-is a fork of the theme [Hermit](https://themes.gohugo.io/themes/hermit/)
+The website is hosted via [GitHub Pages](https://pages.github.com/).
+It was made with the static site generator [Hugo](https://gohugo.io/),
+and the theme is [Hermit](https://themes.gohugo.io/themes/hermit/)
 ([repo](https://github.com/Track3/hermit)).
 
 ## Developers
@@ -19,3 +20,9 @@ curl -s \
   https://raw.githubusercontent.com/github/gitignore/master/{Global/Vim,Global/VisualStudioCode,Global/macOS,community/Golang/Hugo}.gitignore \
   > .gitignore
 ```
+
+## Style
+
+Markdown content in this website are written using [semantic linefeeds][1].
+
+[1]: https://rhodesmill.org/brandon/2012/one-sentence-per-line/

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -3,4 +3,3 @@ title: "{{ replace .Name "-" " " | title }}"
 date: {{ .Date }}
 draft: true
 ---
-


### PR DESCRIPTION
- Updated the repo name from `onetwofoureight` to `onetwofoureight.com`
- Updated `README` content to better describe things, and link the actual website
- Added lint and test GitHub Action beginnings
- Added `pre-commit` files to run in GitHub Actions