### PR TITLE
Documenting fork in README

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -1,6 +1,6 @@
 ---
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to Pages
+name: Deploy Site
 
 on: # yamllint disable-line rule:truthy
   # Runs on pushes targeting the default branch

--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # onetwofoureight.com
 
+![Lint and Test](https://github.com/jamesbraza/onetwofoureight/actions/workflows/lint-test.yaml/badge.svg)
+![Deploy Site](https://github.com/jamesbraza/onetwofoureight/actions/workflows/hugo.yaml/badge.svg)
+
 Files underpinning https://onetwofoureight.com/
 
 ## Website
 
 The website is hosted via [GitHub Pages](https://pages.github.com/).
 It was made with the static site generator [Hugo](https://gohugo.io/),
-and the theme is [Hermit](https://themes.gohugo.io/themes/hermit/)
-([repo](https://github.com/Track3/hermit)).
+and the theme is a fork of [Hermit](https://themes.gohugo.io/themes/hermit/)
+([base repo][2], [fork repo][3]).
 
 ## Developers
 
@@ -26,3 +29,5 @@ curl -s \
 Markdown content in this website are written using [semantic linefeeds][1].
 
 [1]: https://rhodesmill.org/brandon/2012/one-sentence-per-line/
+[2]: https://github.com/Track3/hermit
+[3]: https://github.com/jamesbraza/hermit


### PR DESCRIPTION
Documented the fork of `hermit` in the README.

While I was at it, I renamed the Hugo deploy workflow and added README badges of the GitHub Actions.