### PR TITLE
Fixing deploy download of `hugo`

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -34,7 +34,7 @@ jobs:
         # NOTE: extended is required for custom CSS (e.g. overriding partials):
         # https://github.com/1bl4z3r/hermit-V2/tree/v1.0.2#customize-css
         run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
         # yamllint enable rule:line-length
       - name: Checkout


### PR DESCRIPTION
https://github.com/jamesbraza/onetwofoureight.com/pull/10 migrates from Hugo 0.102.3 to 0.119.0, which no longer has `Linux-64bit.deb` in release assets.

This PR updates the way the `hugo.yaml` action downloads the `hugo` binary